### PR TITLE
experimentally support JUnit for TAP reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ sonar.perl.testHarness.archivePath=testReport.tgz
 # sonar.exclusions=READ*,Change*,COPY*,AUTH*,perlcritic_report.txt
 ```
 
-- Execute your tests and save the report as `testReport.tgz`. We require a format compatible with `Test::Harness::Archive`.
+- Execute your tests and save the report as `testReport.tgz`. We require a format compatible with `TAP::Harness::Archive`.
 
 ```sh
 prove -t -a testReport.tgz
@@ -130,11 +130,14 @@ generate JUnit XML reports, `TAP::Harness::JUnit` and `TAP::Formatter::JUnit`.
 As the plugin would need to extract the test file names from the reports,
 some specific settings are required when using these JUnit modules.
 
-For `TAP::Harness::JUnit` you can generate a single report file.
+For `TAP::Harness::JUnit` you can generate a single report file. The namemangle
+mode has to be "perl" or "none" to allow test file names to be recovered
+from the JUnit report. Note that with the "perl" mode you shall not have
+multiple dots in your test file name, like `foo.bar.t`. And the "none" mode
+may not work well with some JUnit XML report consumer software.
 
 ```sh
 # below would defaultly generate a junit_output.xml
-# JUNIT_NAME_MANGLE has to be "perl" or "none"
 JUNIT_NAME_MANGLE=perl prove --harness TAP::Harness::JUnit ...
 ```
 ```            
@@ -195,6 +198,6 @@ So, if you're interested, get in touch with us!
 
 ## Links
 
-* [Devel::Cover::Report::Clover](http://search.cpan.org/dist/Devel-Cover-Report-Clover/lib/Devel/Cover/Report/Clover.pm) ([source](https://github.com/captin411/devel-cover-report-clover/)) 1.01+ for coverage details. Please install [Sonar Clover Plugin](http://docs.sonarqube.org/display/SONARQUBE45/Clover+Plugin) for reading the coverage report.
-* Perl [TAP](https://testanything.org/), and [TAP::Harness::Archive](http://search.cpan.org/~schwigon/TAP-Harness-Archive-0.18/lib/TAP/Harness/Archive.pm), [TAP::Harness::JUnit](https://metacpan.org/pod/TAP::Harness::JUnit), [TAP::Formatter::JUnit](https://metacpan.org/pod/TAP::Formatter::JUnit), for test reporting.
+* [Devel::Cover::Report::Clover](https://metacpan.org/pod/Devel::Cover::Report::Clover) ([source](https://github.com/captin411/devel-cover-report-clover/)) 1.01+ for coverage details. Please install [Sonar Clover Plugin](http://docs.sonarqube.org/display/SONARQUBE45/Clover+Plugin) for reading the coverage report.
+* Perl [TAP](https://testanything.org/), and [TAP::Harness::Archive](https://metacpan.org/pod/TAP::Harness::Archive), [TAP::Harness::JUnit](https://metacpan.org/pod/TAP::Harness::JUnit), [TAP::Formatter::JUnit](https://metacpan.org/pod/TAP::Formatter::JUnit), for test reporting.
 * [Perl::Critic](http://perlcritic.org/) for issue reporting.

--- a/README.md
+++ b/README.md
@@ -125,6 +125,38 @@ sonar.perl.testHarness.archivePath=testReport.tgz
 prove -t -a testReport.tgz
 ```
 
+We also support JUnit reports. There are mainly two CPAN modules that can
+generate JUnit XML reports, `TAP::Harness::JUnit` and `TAP::Formatter::JUnit`.
+As the plugin would need to extract the test file names from the reports,
+some specific settings are required when using these JUnit modules.
+
+For `TAP::Harness::JUnit` you can generate a single report file.
+
+```sh
+# below would defaultly generate a junit_output.xml
+# JUNIT_NAME_MANGLE has to be "perl" or "none"
+JUNIT_NAME_MANGLE=perl prove --harness TAP::Harness::JUnit ...
+```
+```            
+# in sonar-project.properties
+sonar.perl.testHarness.junitPath=junit_output.xml
+```
+
+For `TAP::Formatter::JUnit`
+```sh
+# generate individual JUnit XML files into a directory
+mkdir junit_output
+PERL_TEST_HARNESS_DUMP_TAP=junit_output prove --formatter TAP::Formatter::JUnit --timer ...
+```
+```            
+# in sonar-project.properties
+sonar.perl.testHarness.junitPath=junit_output
+```
+
+The plugin would firstly try to scan `testReport.tgz`, or whatever specified via
+`sonar.perl.testHarness.archivePath`. Only if the archive report does not exist,
+it would look at the JUnit settings.
+
 - Generate coverage reports in Clover-format (requires version 1.01 or later of `Devel::Cover::Report::Clover`)
 
 ```sh
@@ -164,5 +196,5 @@ So, if you're interested, get in touch with us!
 ## Links
 
 * [Devel::Cover::Report::Clover](http://search.cpan.org/dist/Devel-Cover-Report-Clover/lib/Devel/Cover/Report/Clover.pm) ([source](https://github.com/captin411/devel-cover-report-clover/)) 1.01+ for coverage details. Please install [Sonar Clover Plugin](http://docs.sonarqube.org/display/SONARQUBE45/Clover+Plugin) for reading the coverage report.
-* Perl [TAP](https://testanything.org/) and [TAP::Harness::Archive](http://search.cpan.org/~schwigon/TAP-Harness-Archive-0.18/lib/TAP/Harness/Archive.pm) for test reporting.
+* Perl [TAP](https://testanything.org/), and [TAP::Harness::Archive](http://search.cpan.org/~schwigon/TAP-Harness-Archive-0.18/lib/TAP/Harness/Archive.pm), [TAP::Harness::JUnit](https://metacpan.org/pod/TAP::Harness::JUnit), [TAP::Formatter::JUnit](https://metacpan.org/pod/TAP::Formatter::JUnit), for test reporting.
 * [Perl::Critic](http://perlcritic.org/) for issue reporting.

--- a/its/plugin/projects/tap_junit1/junit_reports/t/Project.t
+++ b/its/plugin/projects/tap_junit1/junit_reports/t/Project.t
@@ -1,0 +1,3 @@
+ok 1 - should be hello
+not ok 2 - Have some failing test
+1..2

--- a/its/plugin/projects/tap_junit1/junit_reports/t/Project.t.junit.xml
+++ b/its/plugin/projects/tap_junit1/junit_reports/t/Project.t.junit.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<testsuites>
+  <testsuite name="Project_t"
+             errors="1"
+             time="0.0792479515075684"
+             failures="1"
+             tests="2">
+    <testcase time="0.0751368999481201" name="1 - should be hello"></testcase>
+    <testcase time="0.000566005706787109" name="2 - Have some failing test">
+      <failure message="not ok 2 - Have some failing test"
+               type="TestFailed"><![CDATA[not ok 2 - Have some failing test]]></failure>
+    </testcase>
+    <testcase name="(teardown)" time="0.00325489044189453" />
+    <system-out><![CDATA[ok 1 - should be hello
+not ok 2 - Have some failing test
+1..2
+]]></system-out>
+    <system-err><![CDATA[Dubious, test returned 1 (wstat 256, 0x100)
+]]></system-err>
+    <error message="Dubious, test returned 1 (wstat 256, 0x100)" />
+  </testsuite>
+</testsuites>

--- a/its/plugin/projects/tap_junit1/lib/Sample/Project.pm
+++ b/its/plugin/projects/tap_junit1/lib/Sample/Project.pm
@@ -1,0 +1,61 @@
+package Sample::Project;
+
+$VERSION = '0.1';
+
+sub new {
+    my $class = shift;
+    my %args  = @_;
+    my $self  = bless \%args, $class;
+    return $self;
+}
+
+# say hello
+sub hello {
+    if($VERSION > $VERSION + 1) {
+        return "well..";
+    }
+    return "hello";
+}
+
+# say goodbye
+sub goodbye {
+    return "goodbye";
+}
+
+=pod
+
+=head1 NAME
+
+C<IO::Socket::IP> - Family-neutral IP socket supporting both IPv4 and IPv6
+
+=head1 SYNOPSIS
+
+ use IO::Socket::IP;
+
+ my $sock = IO::Socket::IP->new(
+    PeerHost => "www.google.com",
+    PeerPort => "http",
+    Type     => SOCK_STREAM,
+ ) or die "Cannot construct socket - $@";
+
+ my $familyname = ( $sock->sockdomain == PF_INET6 ) ? "IPv6" :
+                  ( $sock->sockdomain == PF_INET  ) ? "IPv4" :
+                                                      "unknown";
+
+ printf "Connected to google via %s\n", $familyname;
+
+=head1 DESCRIPTION
+
+This module provides a protocol-independent way to use IPv4 and IPv6 sockets,
+intended as a replacement for L<IO::Socket::INET>. Most constructor arguments
+and methods are provided in a backward-compatible way. For a list of known
+differences, see the C<IO::Socket::INET> INCOMPATIBILITES section below.
+
+It uses the C<getaddrinfo(3)> function to convert hostnames and service names
+or port numbers into sets of possible addresses to connect to or listen on.
+This allows it to work for IPv6 where the system supports it, while still
+falling back to IPv4-only on systems which don't.
+
+=cut
+
+1;

--- a/its/plugin/projects/tap_junit1/t/Project.t
+++ b/its/plugin/projects/tap_junit1/t/Project.t
@@ -1,0 +1,10 @@
+use lib 'lib';
+use Test::More;
+use Sample::Project;
+
+my $project = Sample::Project->new();
+is($project->hello, 'hello', 'should be hello');
+fail("Have some failing test");
+done_testing;
+
+1;

--- a/its/plugin/projects/tap_junit2/junit_output.xml
+++ b/its/plugin/projects/tap_junit2/junit_output.xml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='utf-8'?>
+<testsuites>
+  <testsuite name="t.Project_t" errors="0" failures="1" skipped="0" tests="2" time="0.0793290138244629">
+    <system-out>ok 1 - should be hello
+not ok 2 - Have some failing test
+1..2
+</system-out>
+    <testcase name="should be hello" classname="t.Project_t" time="0.0751869678497314" />
+    <testcase name="Have some failing test" classname="t.Project_t" time="0.000247955322265625">
+      <failure message="not ok 2 - Have some failing test" type="TAP::Parser::Result::Test"></failure>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/its/plugin/projects/tap_junit2/lib/Sample/Project.pm
+++ b/its/plugin/projects/tap_junit2/lib/Sample/Project.pm
@@ -1,0 +1,61 @@
+package Sample::Project;
+
+$VERSION = '0.1';
+
+sub new {
+    my $class = shift;
+    my %args  = @_;
+    my $self  = bless \%args, $class;
+    return $self;
+}
+
+# say hello
+sub hello {
+    if($VERSION > $VERSION + 1) {
+        return "well..";
+    }
+    return "hello";
+}
+
+# say goodbye
+sub goodbye {
+    return "goodbye";
+}
+
+=pod
+
+=head1 NAME
+
+C<IO::Socket::IP> - Family-neutral IP socket supporting both IPv4 and IPv6
+
+=head1 SYNOPSIS
+
+ use IO::Socket::IP;
+
+ my $sock = IO::Socket::IP->new(
+    PeerHost => "www.google.com",
+    PeerPort => "http",
+    Type     => SOCK_STREAM,
+ ) or die "Cannot construct socket - $@";
+
+ my $familyname = ( $sock->sockdomain == PF_INET6 ) ? "IPv6" :
+                  ( $sock->sockdomain == PF_INET  ) ? "IPv4" :
+                                                      "unknown";
+
+ printf "Connected to google via %s\n", $familyname;
+
+=head1 DESCRIPTION
+
+This module provides a protocol-independent way to use IPv4 and IPv6 sockets,
+intended as a replacement for L<IO::Socket::INET>. Most constructor arguments
+and methods are provided in a backward-compatible way. For a list of known
+differences, see the C<IO::Socket::INET> INCOMPATIBILITES section below.
+
+It uses the C<getaddrinfo(3)> function to convert hostnames and service names
+or port numbers into sets of possible addresses to connect to or listen on.
+This allows it to work for IPv6 where the system supports it, while still
+falling back to IPv4-only on systems which don't.
+
+=cut
+
+1;

--- a/its/plugin/projects/tap_junit2/t/Project.t
+++ b/its/plugin/projects/tap_junit2/t/Project.t
@@ -1,0 +1,10 @@
+use lib 'lib';
+use Test::More;
+use Sample::Project;
+
+my $project = Sample::Project->new();
+is($project->hello, 'hello', 'should be hello');
+fail("Have some failing test");
+done_testing;
+
+1;

--- a/its/plugin/src/test/java/com/github/otrosien/perl/it/TestMetricsIntegrationJUnit1Test.java
+++ b/its/plugin/src/test/java/com/github/otrosien/perl/it/TestMetricsIntegrationJUnit1Test.java
@@ -1,0 +1,62 @@
+package com.github.otrosien.perl.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.sonar.wsclient.Sonar;
+import org.sonar.wsclient.services.Measure;
+import org.sonar.wsclient.services.Resource;
+import org.sonar.wsclient.services.ResourceQuery;
+
+import com.sonar.orchestrator.Orchestrator;
+import com.sonar.orchestrator.build.SonarScanner;
+import com.sonar.orchestrator.locator.FileLocation;
+
+public class TestMetricsIntegrationJUnit1Test {
+
+    private static final String PROJECT_KEY = "tap_junit1";
+
+    @ClassRule
+    public static Orchestrator orchestrator = Orchestrator.builderEnv()
+      .setSonarVersion("6.1")
+      .addPlugin(FileLocation.byWildcardMavenFilename(new File("../../sonar-perl-plugin/build/libs"), "sonar-perl-plugin-*.jar"))
+      .build();
+
+    private static Sonar wsClient;
+
+    @BeforeClass
+    public static void startServer() {
+        SonarScanner build = SonarScanner.create()
+                .setProjectDir(new File("projects/tap_junit1"))
+                .setProjectKey(PROJECT_KEY)
+                .setProjectName(PROJECT_KEY)
+                .setProjectVersion("1.0-SNAPSHOT")
+                .setProperty("sonar.perl.testHarness.junitPath", "junit_reports")
+                .setSourceDirs("lib")
+                .setTestDirs("t");
+        orchestrator.executeBuild(build);
+
+        wsClient = orchestrator.getServer().getWsClient();
+    }
+
+    @Test
+    public void file_level() {
+      // test count
+        assertThat(getFileMeasure("tests").getIntValue()).isEqualTo(2);
+        assertThat(getFileMeasure("test_failures").getIntValue()).isEqualTo(1);
+    }
+
+    private Measure getFileMeasure(String metricKey) {
+      Resource resource = wsClient.find(ResourceQuery.createForMetrics(keyFor("Project.t"), metricKey));
+      return resource == null ? null : resource.getMeasure(metricKey);
+    }
+
+    private static String keyFor(String s) {
+      return PROJECT_KEY + ":t/" + s;
+    }
+
+}

--- a/its/plugin/src/test/java/com/github/otrosien/perl/it/TestMetricsIntegrationJUnit2Test.java
+++ b/its/plugin/src/test/java/com/github/otrosien/perl/it/TestMetricsIntegrationJUnit2Test.java
@@ -1,0 +1,62 @@
+package com.github.otrosien.perl.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.sonar.wsclient.Sonar;
+import org.sonar.wsclient.services.Measure;
+import org.sonar.wsclient.services.Resource;
+import org.sonar.wsclient.services.ResourceQuery;
+
+import com.sonar.orchestrator.Orchestrator;
+import com.sonar.orchestrator.build.SonarScanner;
+import com.sonar.orchestrator.locator.FileLocation;
+
+public class TestMetricsIntegrationJUnit2Test {
+
+    private static final String PROJECT_KEY = "tap_junit2";
+
+    @ClassRule
+    public static Orchestrator orchestrator = Orchestrator.builderEnv()
+      .setSonarVersion("6.1")
+      .addPlugin(FileLocation.byWildcardMavenFilename(new File("../../sonar-perl-plugin/build/libs"), "sonar-perl-plugin-*.jar"))
+      .build();
+
+    private static Sonar wsClient;
+
+    @BeforeClass
+    public static void startServer() {
+        SonarScanner build = SonarScanner.create()
+                .setProjectDir(new File("projects/tap_junit2"))
+                .setProjectKey(PROJECT_KEY)
+                .setProjectName(PROJECT_KEY)
+                .setProjectVersion("1.0-SNAPSHOT")
+                .setProperty("sonar.perl.testHarness.junitPath", "junit_output.xml")
+                .setSourceDirs("lib")
+                .setTestDirs("t");
+        orchestrator.executeBuild(build);
+
+        wsClient = orchestrator.getServer().getWsClient();
+    }
+
+    @Test
+    public void file_level() {
+      // test count
+        assertThat(getFileMeasure("tests").getIntValue()).isEqualTo(2);
+        assertThat(getFileMeasure("test_failures").getIntValue()).isEqualTo(1);
+    }
+
+    private Measure getFileMeasure(String metricKey) {
+      Resource resource = wsClient.find(ResourceQuery.createForMetrics(keyFor("Project.t"), metricKey));
+      return resource == null ? null : resource.getMeasure(metricKey);
+    }
+
+    private static String keyFor(String s) {
+      return PROJECT_KEY + ":t/" + s;
+    }
+
+}

--- a/sonar-perl-plugin/src/main/java/com/github/otrosien/sonar/perl/tap/TestHarnessJUnitProperties.java
+++ b/sonar-perl-plugin/src/main/java/com/github/otrosien/sonar/perl/tap/TestHarnessJUnitProperties.java
@@ -1,0 +1,7 @@
+package com.github.otrosien.sonar.perl.tap;
+
+public class TestHarnessJUnitProperties { // NOSONAR
+
+    public static final String HARNESS_JUNIT_PATH_KEY = "sonar.perl.testHarness.junitPath";
+
+}

--- a/sonar-perl-plugin/src/main/java/com/github/otrosien/sonar/perl/tap/TestHarnessJUnitReader.java
+++ b/sonar-perl-plugin/src/main/java/com/github/otrosien/sonar/perl/tap/TestHarnessJUnitReader.java
@@ -1,0 +1,175 @@
+package com.github.otrosien.sonar.perl.tap;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.io.InputStreamReader;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
+
+import com.github.otrosien.sonar.perl.tap.TestHarnessReport.Test;
+import com.github.otrosien.sonar.perl.tap.TestHarnessReport.TestDetail;
+import com.github.otrosien.sonar.perl.tap.TestHarnessReport.TestDetail.TestDetailBuilder;
+import com.github.otrosien.sonar.perl.tap.TestHarnessReport.TestHarnessReportBuilder;
+
+/*
+A difficulty with JUnit reports is that we need to recover test file path
+info.
+
+There are mainly two Perl modules that supports generating JUnit XML,
+one is TAP::Harness::JUnit, the other is TAP::Formatter::JUnit.
+
+For TAP::Formatter::JUnit, we would support if it dumps to individual
+files under a directory via setting PERL_TEST_HARNESS_DUMP_TAP.  The junit
+xml files are named by appending .junit.xml to the t/xxx.t form.
+
+For TAP::Harness::JUnit, we would assume its namemangle is "none" or
+"perl".  We cannot support "hudson" mode as we can't safely recover test
+file path in this case.  Actually even "perl" mode is not 100% safe
+although it should work well in most cases. 
+*/
+
+public class TestHarnessJUnitReader {
+
+    private static final Logger log = Loggers.get(TestHarnessJUnitReader.class);
+
+    private Pattern tapNumberOfTests = Pattern.compile("^1\\.\\.(\\d+).*");
+
+    public Optional<TestHarnessReport> read(File file) throws IOException {
+        Path path = Paths.get(file.getPath());
+        TestHarnessReport.TestHarnessReportBuilder builder = TestHarnessReport.builder();
+
+        if (Files.isDirectory(path)) { // for TAP::Formatter::JUnit
+            log.info("Looking for JUnit reports under path {}", path.toString());
+
+            List<Path> files = Files.walk(path)
+                .filter(Files::isRegularFile)
+                .filter(p -> p.toString().endsWith(".junit.xml"))
+                .collect(Collectors.toList());
+
+            boolean rslt = false;
+            for (Path p : files) {
+                rslt |= readReport(builder, p, path);
+            };
+            if (rslt) {
+                // got data from at least one of the junit xml files
+                return Optional.of(builder.build());
+            } 
+        }
+        else {      // for TAP::Harness::JUnit
+            if (readReport(builder, path, path)) {
+                return Optional.of(builder.build());
+            } 
+        }
+
+        return Optional.empty();
+    }
+
+    private boolean readReport( TestHarnessReport.TestHarnessReportBuilder builder,
+                            Path path, 
+                            Path reportRootPath ) {
+        String reportPath = path.toString();
+        log.info("Reading JUnit report from file {}", reportPath);
+
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+
+        try {
+            InputSource is = new InputSource(
+                                    Files.newBufferedReader(path, StandardCharsets.UTF_8));
+            DocumentBuilder db = dbf.newDocumentBuilder();
+            Document doc = db.parse(is);
+
+            NodeList testsuites = doc.getElementsByTagName("testsuite");
+
+            for (int i = 0; i < testsuites.getLength(); i++) {
+                Element testsuite = (Element)(testsuites.item(i));
+                
+                String tsname = testsuite.getAttribute("name");
+                String filepath;
+                if (reportPath.endsWith(".t.junit.xml") && path != reportRootPath) {
+                    // assume TAP::Formatter::JUnit with PERL_TEST_HARNESS_DUMP_TAP
+                    filepath = reportRootPath.relativize(path)
+                                    .toString()
+                                    .replaceAll("\\.junit\\.xml$", "");
+                } else {
+                    // assume TAP::Harness::JUnit
+                    filepath = tsname;
+                    if (!tsname.endsWith(".t")) {
+                        // assume namemangle is "perl"
+                        filepath = tsname.replace('.', '/').replaceAll("_t$", ".t");
+                    } 
+                }
+            
+                builder.addTest(
+                    new Test((String) tsname,
+                             new BigDecimal(0),
+                             new BigDecimal((String) testsuite.getAttribute("time"))));
+
+                TestDetailBuilder detailBuilder = TestDetail.builder();
+                detailBuilder.filePath(filepath);
+
+                NodeList outnodes = testsuite.getElementsByTagName("system-out");
+                if (outnodes.getLength() > 0) {
+                    String systemout = ((Element)outnodes.item(0)).getTextContent();
+                    BufferedReader br = new BufferedReader(new StringReader(systemout));
+                    br.lines().forEach(line -> {
+                        if (line.startsWith("ok ")) {
+                            detailBuilder.ok();
+                        } else if (line.startsWith("not ok ")) {
+                            detailBuilder.failed();
+                        } else if (line.startsWith("1..")) {
+                            Matcher m = tapNumberOfTests.matcher(line);
+                            if (m.matches()) {
+                                detailBuilder.total(Integer.valueOf(m.group(1)));
+                            }
+                        }
+                    });
+
+                    TestDetail detail = detailBuilder.build();
+                    if (detail.getNumberOfTests() > 0) {
+                        builder.addTestDetail(detail);
+                        continue;
+                    }
+                }
+
+                log.info("Did not recognize TAP or tests skipped completely: " + filepath);
+            }
+            return true;
+            
+        } catch (IOException e) {
+            log.error("IO exception: ", e);
+        } catch (SAXException e) {
+            log.error("Failed parsing JUnit report: ", e);
+        } catch (ParserConfigurationException e) {
+            log.error("Parser configuration exception: ", e);
+        }
+        return false;
+    }
+}
+    


### PR DESCRIPTION
This is for #46 

Some notes:

- There are mainly two JUnit modules on CPAN: TAP::Harness::JUnit and TAP::Formatter::JUnit. For each of them we would need some specific settings to make it possible to extract/recover test file names from the JUnit xml reports. I've documented it in README.

- IMHO the TestHarnessReport class now is quite fitting TAP::Harness::Archive in that it does start/stop time of the harness and individual test files, and in contrast JUnit report has only duration for each test file. It's now not very natural (although totally doable) to store the JUnit data into TestHarnessReport, but at this moment I am not going to change TestHarnessReport. 

- If  you think this P/R is basically fine then I will go on to write test projects. 

