### PR TITLE
Only include fat-jar in docker image

### DIFF
--- a/sonar-perl-plugin/build.gradle
+++ b/sonar-perl-plugin/build.gradle
@@ -79,7 +79,8 @@ task copyDockerTargetArtifacts(type: Copy) {
     group = 'Docker'
     description = 'Assembles contents for docker image.'
     dependsOn copyDockerfile, shadowJar
-    from "build/libs/"
+    from "build/libs/" 
+    include "*-all.jar"
     into "build/docker/build/libs/"
 }
 


### PR DESCRIPTION
If we add both jars sonar will refuse to start.