### PR TITLE
Compile for Java 8 using Java 11

### DIFF
--- a/perl-frontend/build.gradle
+++ b/perl-frontend/build.gradle
@@ -13,6 +13,10 @@ java {
     }
 }
 
+compileJava {
+    options.release = 8
+}
+
 jacoco {
     toolVersion = '0.8.6'
 }

--- a/sonar-perl-plugin/build.gradle
+++ b/sonar-perl-plugin/build.gradle
@@ -34,6 +34,10 @@ java {
     }
 }
 
+compileJava {
+    options.release = 8
+}
+
 jacoco {
     toolVersion = '0.8.6'
 }


### PR DESCRIPTION
Build `perl-frontend` and `sonar-perl-plugin` using Java 11:
```
java {
    toolchain {
        languageVersion = JavaLanguageVersion.of(11)
    }
}
```

But build to allow execution on Java 8 (see `javac` `--release` option):
```
compileJava {
    options.release = 8
}
```

Option is also required for `perl-frontend` as `sonar-perl-plugin` has a dependency on it (for example for `PerlConfiguration` class).

Closes #117 