### PR TITLE
Get sonar-clover-plugin from Sonatype public repo

### DIFF
--- a/sonar-perl-plugin/Dockerfile
+++ b/sonar-perl-plugin/Dockerfile
@@ -1,4 +1,4 @@
 FROM sonarqube:7.9-community
 
-ADD --chown=sonarqube:sonarqube https://s01.oss.sonatype.org/service/local/repo_groups/public/content/io/github/sfeir-open-source/sonar-clover-plugin/4.1-SNAPSHOT/sonar-clover-plugin-4.1-20210511.125508-2.jar /opt/sonarqube/extensions/plugins/sonar-clover-plugin-4.1.jar
+ADD --chown=sonarqube:sonarqube https://repo1.maven.org/maven2/io/github/sfeir-open-source/sonar-clover-plugin/4.1/sonar-clover-plugin-4.1.jar /opt/sonarqube/extensions/plugins/sonar-clover-plugin-4.1.jar
 COPY --chown=sonarqube:sonarqube build/libs/*all.jar /opt/sonarqube/extensions/plugins/

--- a/sonar-perl-plugin/Dockerfile
+++ b/sonar-perl-plugin/Dockerfile
@@ -1,4 +1,4 @@
 FROM sonarqube:7.9-community
 
-ADD --chown=sonarqube:sonarqube https://bintray.com/sfeir-open-source/maven/download_file?file_path=org%2Fsfeir%2Fsonar-clover-plugin%2F4.1%2Fsonar-clover-plugin-4.1.jar /opt/sonarqube/extensions/plugins/sonar-clover-plugin-4.1.jar
+ADD --chown=sonarqube:sonarqube https://s01.oss.sonatype.org/service/local/repo_groups/public/content/io/github/sfeir-open-source/sonar-clover-plugin/4.1-SNAPSHOT/sonar-clover-plugin-4.1-20210511.125508-2.jar /opt/sonarqube/extensions/plugins/sonar-clover-plugin-4.1.jar
 COPY --chown=sonarqube:sonarqube build/libs/*all.jar /opt/sonarqube/extensions/plugins/


### PR DESCRIPTION
As sonar-clover-plugin is no longer available from Bintray get it from Sonatype public repository until it get available from Maven Central. Synchronization to Maven Central is currently failing according to https://issues.sonatype.org/browse/OSSRH-67181?focusedCommentId=1058323&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1058323