### PR TITLE
Accept unknown perlcritic violations & use severity from perlcritic report 

### DIFF
--- a/perl/sample-project/perlcritic_report.txt
+++ b/perl/sample-project/perlcritic_report.txt
@@ -16,3 +16,4 @@ t/Project.t~|~4~|~1~|~1~|~Code not contained in explicit package~|~Violates enca
 t/Project.t~|~2~|~1~|~1~|~No package-scoped "$VERSION" variable found~|~See page 404 of PBP~|~Modules::RequireVersionVar~||~
 t/Project.t~|~5~|~5~|~1~|~Code before strictures are enabled~|~See page 429 of PBP~|~TestingAndDebugging::RequireUseStrict~||~
 t/Project.t~|~4~|~5~|~1~|~Code before warnings are enabled~|~See page 431 of PBP~|~TestingAndDebugging::RequireUseWarnings~||~
+t/Project.t~|~4~|~5~|~1~|~xy~|~test~|~Unknown::UnknownCriticRule~||~

--- a/sonar-perl-plugin/src/main/java/com/github/sonarperl/critic/PerlCriticAnalysisResultsParser.java
+++ b/sonar-perl-plugin/src/main/java/com/github/sonarperl/critic/PerlCriticAnalysisResultsParser.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.sonar.api.rule.Severity;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 
@@ -59,7 +60,21 @@ class PerlCriticAnalysisResultsParser {
         }
 
         // @see org.epic.perleditor.editors.util.SourceCritic
-        return Optional.of(new PerlCriticViolation(fields[6], fields[4], fields[0], "".equals(fields[2]) ? -1 : Integer.parseInt(fields[2]), Integer.parseInt(fields[1])));
+        return Optional.of(new PerlCriticViolation(fields[6], fields[4], fields[0], "".equals(fields[2]) ? -1 : Integer.parseInt(fields[2]), severityString(fields[1])));
     }
 
+    static String severityString(String severity) {
+        // INFO, MINOR, MAJOR, CRITICAL, BLOCKER
+        switch (severity) {
+            case "1": return Severity.INFO;
+            case "2": return Severity.MINOR;
+            case "3": return Severity.MAJOR;
+            case "4": return Severity.CRITICAL;
+            case "5": return Severity.BLOCKER;
+            default: {
+                log.warn("unknown severity value '{}'", severity);
+                return Severity.defaultSeverity();
+            }
+        }
+    }
 }

--- a/sonar-perl-plugin/src/main/java/com/github/sonarperl/critic/PerlCriticAnalysisResultsParser.java
+++ b/sonar-perl-plugin/src/main/java/com/github/sonarperl/critic/PerlCriticAnalysisResultsParser.java
@@ -40,7 +40,7 @@ class PerlCriticAnalysisResultsParser {
      *
      *  // %f~|~%s~|~%l~|~%c~|~%m~|~%e~|~%p~||~%n
      *
-     * See {@link https://github.com/jploski/epic-ide/blob/b70f1c5ccb3e528f3a8c727b04dc633439f1d35a/org.epic.perleditor/src/org/epic/perleditor/editors/util/SourceCritic.java}
+     * See {@link <a href="https://github.com/jploski/epic-ide/blob/b70f1c5ccb3e528f3a8c727b04dc633439f1d35a/org.epic.perleditor/src/org/epic/perleditor/editors/util/SourceCritic.java">...</a>}
      */
     private Optional<PerlCriticViolation> parseLine(String line) {
         if(line.endsWith("OK")) {
@@ -59,7 +59,7 @@ class PerlCriticAnalysisResultsParser {
         }
 
         // @see org.epic.perleditor.editors.util.SourceCritic
-        return Optional.of(new PerlCriticViolation(fields[6], fields[4], fields[0], "".equals(fields[2]) ? -1 : Integer.parseInt(fields[2])));
+        return Optional.of(new PerlCriticViolation(fields[6], fields[4], fields[0], "".equals(fields[2]) ? -1 : Integer.parseInt(fields[2]), Integer.parseInt(fields[1])));
     }
 
 }

--- a/sonar-perl-plugin/src/main/java/com/github/sonarperl/critic/PerlCriticIssuesLoaderSensor.java
+++ b/sonar-perl-plugin/src/main/java/com/github/sonarperl/critic/PerlCriticIssuesLoaderSensor.java
@@ -9,12 +9,15 @@ import org.sonar.api.batch.fs.FileSystem;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.InputFile.Type;
 import org.sonar.api.batch.rule.ActiveRules;
+import org.sonar.api.batch.rule.Severity;
 import org.sonar.api.batch.sensor.Sensor;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.SensorDescriptor;
+import org.sonar.api.batch.sensor.issue.NewExternalIssue;
 import org.sonar.api.batch.sensor.issue.NewIssue;
 import org.sonar.api.batch.sensor.issue.NewIssueLocation;
 import org.sonar.api.rule.RuleKey;
+import org.sonar.api.rules.RuleType;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 
@@ -84,31 +87,53 @@ public class PerlCriticIssuesLoaderSensor implements Sensor {
                     .inputFile(fileSystem.predicates().hasRelativePath(violation.getFilePath()));
 
             if (inputFile != null) {
-                saveIssue(inputFile, violation.getLine(), violation.getType(), violation.getDescription());
+                saveIssue(inputFile, violation);
             } else {
                 log.warn("Not able to find an input file with path '{}'", violation.getFilePath());
             }
         }
 
-        void saveIssue(InputFile inputFile, int line, String externalRuleKey, String message) {
+        void saveIssue(InputFile inputFile, PerlCriticViolation violation) {
+            int line = violation.getLine();
+            String externalRuleKey = violation.getType();
+            String message = violation.getDescription();
+            Severity severity = Severity.valueOf(violation.getSeverity());
+
             RuleKey rule = RuleKey.of(PerlCriticRulesDefinition.getRepositoryKey(), externalRuleKey);
-
-            if (activeRules.find(rule) == null) {
-                log.info("Ignoring unknown or deactivated issue of type {}", rule);
-                return;
-            }
-
             log.debug("Saving an issue of type {} on file {}", rule, inputFile);
+            if (activeRules.find(rule) == null) {
+                // unknown perlcritic rule
+                log.info("Found an unknown or deactivated issue of type {}", rule);
+                NewExternalIssue issue = this.context.newExternalIssue()
+                        .engineId(PerlCriticRulesDefinition.getRepositoryKey())
+                        .ruleId(externalRuleKey)
+                        // don't have any other indicators
+                        .type(RuleType.CODE_SMELL)
+                        .severity(severity);
 
-            NewIssue issue = this.context.newIssue().forRule(rule);
-            NewIssueLocation location = issue.newLocation().message(message).on(inputFile);
+                NewIssueLocation location = issue
+                        .newLocation()
+                        .message(message)
+                        .on(inputFile);
 
-            if (line > 0) {
-                location.at(inputFile.selectLine(line));
+                if (line > 0) {
+                    location.at(inputFile.selectLine(line));
+                }
+                issue.at(location);
+                issue.save();
+            } else {
+                // known perlcritic rule
+                NewIssue issue = this.context.newIssue()
+                        .forRule(rule);
+
+                NewIssueLocation location = issue.newLocation().message(message).on(inputFile);
+                if (line > 0) {
+                    location.at(inputFile.selectLine(line));
+                }
+                issue.at(location);
+                issue.save();
             }
-
-            issue.at(location);
-            issue.save();
+            return;
         }
 
     }

--- a/sonar-perl-plugin/src/main/java/com/github/sonarperl/critic/PerlCriticIssuesLoaderSensor.java
+++ b/sonar-perl-plugin/src/main/java/com/github/sonarperl/critic/PerlCriticIssuesLoaderSensor.java
@@ -133,7 +133,6 @@ public class PerlCriticIssuesLoaderSensor implements Sensor {
                 issue.at(location);
                 issue.save();
             }
-            return;
         }
 
     }

--- a/sonar-perl-plugin/src/main/java/com/github/sonarperl/critic/PerlCriticIssuesLoaderSensor.java
+++ b/sonar-perl-plugin/src/main/java/com/github/sonarperl/critic/PerlCriticIssuesLoaderSensor.java
@@ -124,7 +124,8 @@ public class PerlCriticIssuesLoaderSensor implements Sensor {
             } else {
                 // known perlcritic rule
                 NewIssue issue = this.context.newIssue()
-                        .forRule(rule);
+                        .forRule(rule)
+                        .overrideSeverity(severity);
 
                 NewIssueLocation location = issue.newLocation().message(message).on(inputFile);
                 if (line > 0) {

--- a/sonar-perl-plugin/src/main/java/com/github/sonarperl/critic/PerlCriticViolation.java
+++ b/sonar-perl-plugin/src/main/java/com/github/sonarperl/critic/PerlCriticViolation.java
@@ -1,17 +1,21 @@
 package com.github.sonarperl.critic;
 
+import org.sonar.api.rule.Severity;
+
 class PerlCriticViolation {
 
     private final String type;
     private final String description;
     private final String filePath;
     private final int line;
+    private final int severity;
 
-    public PerlCriticViolation(final String type, final String description, final String filePath, final int line) {
+    public PerlCriticViolation(final String type, final String description, final String filePath, final int line, final int severity) {
         this.type = type;
         this.description = description;
         this.filePath = filePath;
         this.line = line;
+        this.severity = severity;
     }
 
     public String getType() {
@@ -28,6 +32,18 @@ class PerlCriticViolation {
 
     public int getLine() {
         return line;
+    }
+
+    public String getSeverity() {
+        // INFO, MINOR, MAJOR, CRITICAL, BLOCKER
+        switch (this.severity) {
+            case 1: return Severity.INFO;
+            case 2: return Severity.MINOR;
+            case 3: return Severity.MAJOR;
+            case 4: return Severity.CRITICAL;
+            case 5: return Severity.BLOCKER;
+        }
+        return Severity.defaultSeverity();
     }
 
     @Override

--- a/sonar-perl-plugin/src/main/java/com/github/sonarperl/critic/PerlCriticViolation.java
+++ b/sonar-perl-plugin/src/main/java/com/github/sonarperl/critic/PerlCriticViolation.java
@@ -8,9 +8,9 @@ class PerlCriticViolation {
     private final String description;
     private final String filePath;
     private final int line;
-    private final int severity;
+    private final String severity;
 
-    public PerlCriticViolation(final String type, final String description, final String filePath, final int line, final int severity) {
+    public PerlCriticViolation(final String type, final String description, final String filePath, final int line, final String severity) {
         this.type = type;
         this.description = description;
         this.filePath = filePath;
@@ -35,15 +35,7 @@ class PerlCriticViolation {
     }
 
     public String getSeverity() {
-        // INFO, MINOR, MAJOR, CRITICAL, BLOCKER
-        switch (this.severity) {
-            case 1: return Severity.INFO;
-            case 2: return Severity.MINOR;
-            case 3: return Severity.MAJOR;
-            case 4: return Severity.CRITICAL;
-            case 5: return Severity.BLOCKER;
-        }
-        return Severity.defaultSeverity();
+        return severity;
     }
 
     @Override

--- a/sonar-perl-plugin/src/test/java/com/github/sonarperl/critic/PerlCriticAnalysisResultsParserTest.java
+++ b/sonar-perl-plugin/src/test/java/com/github/sonarperl/critic/PerlCriticAnalysisResultsParserTest.java
@@ -36,4 +36,16 @@ public class PerlCriticAnalysisResultsParserTest {
         return Paths.get(ClassLoader.getSystemResource("basic/perlcritic_report.txt").toURI()).toFile();
     }
 
+
+    @Test
+    public void should_convert_severity() {
+        assertThat(PerlCriticAnalysisResultsParser.severityString("1"), is("INFO"));
+        assertThat(PerlCriticAnalysisResultsParser.severityString("2"), is("MINOR"));
+        assertThat(PerlCriticAnalysisResultsParser.severityString("3"), is("MAJOR"));
+        assertThat(PerlCriticAnalysisResultsParser.severityString("4"), is("CRITICAL"));
+        assertThat(PerlCriticAnalysisResultsParser.severityString("5"), is("BLOCKER"));
+        // default
+        assertThat(PerlCriticAnalysisResultsParser.severityString("6"), is("MAJOR"));
+    }
+
 }

--- a/sonar-perl-plugin/src/test/java/com/github/sonarperl/critic/PerlCriticIssuesLoaderSensorTest.java
+++ b/sonar-perl-plugin/src/test/java/com/github/sonarperl/critic/PerlCriticIssuesLoaderSensorTest.java
@@ -50,6 +50,7 @@ public class PerlCriticIssuesLoaderSensorTest {
         inputFile(relativePath);
         createSensor().execute(context);
         assertThat(context.allIssues()).hasSize(3);
+        assertThat(context.allExternalIssues()).hasSize(1);
     }
 
     @Test


### PR DESCRIPTION
Unknown perlcritic violations are treated as "external issues" of type "code smell". I would have converted all perlcritic violations to external issues, but then we lose the issue type (bug, code-smell, etc) as we don't get those from the perlcritic report.

This change also introduces the mapping of the severity levels 1-5 of the report to the severity levels INFO-BLOCKER of SonarQube.