### PR TITLE
Sonar lint: XXE attack vector

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'pl.allegro.tech.build.axion-release' version '1.15.3'
-    id "org.sonarqube" version "4.1.0.3113"
+    id "org.sonarqube" version "4.2.0.3129"
+    id "com.github.ben-manes.versions" version "0.46.0"
     id 'eclipse'
     id 'idea'
 }

--- a/sonar-perl-plugin/build.gradle
+++ b/sonar-perl-plugin/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     compileOnly "org.sonarsource.api.plugin:sonar-plugin-api:${sonarApiVersion}"
     testImplementation "org.sonarsource.api.plugin:sonar-plugin-api:${sonarApiVersion}"
     testImplementation "org.sonarsource.sonarqube:sonar-plugin-api-impl:${sonarqubeVersion}"
-    implementation 'org.apache.commons:commons-compress:1.21'
+    implementation 'org.apache.commons:commons-compress:1.23.0'
     implementation 'com.esotericsoftware.yamlbeans:yamlbeans:1.13'
     implementation 'com.fasterxml.staxmate:staxmate:2.4.0'
     implementation 'commons-io:commons-io:2.7'
@@ -58,7 +58,7 @@ jar {
                    "Build-Time": new Date().format("yyyy-MM-dd'T'HH:mm:ssZ"),
                    "Plugin-BuildDate": new Date().format("yyyy-MM-dd'T'HH:mm:ssZ"),
                    'Plugin-Key': 'communityperl',
-                   'Plugin-Name': 'Sonar Community Perl',
+                   'Plugin-Name': 'Community Perl',
                    'Plugin-Version': project.version,
                    'Plugin-Class': 'com.github.sonarperl.PerlPlugin',
                    "Plugin-Description": 'Code Analyzer for Perl',

--- a/sonar-perl-plugin/src/main/java/com/github/sonarperl/tap/TestHarnessJUnitReader.java
+++ b/sonar-perl-plugin/src/main/java/com/github/sonarperl/tap/TestHarnessJUnitReader.java
@@ -80,6 +80,7 @@ public class TestHarnessJUnitReader {
         dbf.setAttribute(XMLConstants.FEATURE_SECURE_PROCESSING, Boolean.TRUE);
 
         try {
+            dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
             InputSource is = new InputSource(
                                     Files.newBufferedReader(path, StandardCharsets.UTF_8));
             DocumentBuilder db = dbf.newDocumentBuilder();


### PR DESCRIPTION
## Changes

- update commons-compress and sonarqube plugin
- disallow external resources when xml parsing, as in https://sonarcloud.io/organizations/sonar-perl/rules?open=java%3AS2755&rule_key=java%3AS2755
- add ben-manes.versions plugin

