### PR TITLE
Maintain 9.9 LTS compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is a community-contributed [SonarQube](http://www.sonarqube.org/) [plugin](
 
 ## Version Compatibility
 
-We support SonarQube LTS (9.9) and latest (10.0) releases. Please report bugs or incompatibilities in our [bugtracker](https://github.com/sonar-perl/sonar-perl/issues).
+We support SonarQube LTS (9.9) and latest (10.x) releases. Please report bugs or incompatibilities in our [bugtracker](https://github.com/sonar-perl/sonar-perl/issues).
 
 
 ## Current State

--- a/its/plugin/build.gradle
+++ b/its/plugin/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.sonarsource.orchestrator:sonar-orchestrator-junit4:4.9.0.1920'
-    testImplementation 'org.sonarsource.sonarqube:sonar-ws:10.6.0.92116'
+    testImplementation 'org.sonarsource.sonarqube:sonar-ws:10.7.0.96327'
     testImplementation project(':sonar-perl-plugin')
 }
 

--- a/its/plugin/src/test/java/com/github/sonarperl/it/IntegrationTests.java
+++ b/its/plugin/src/test/java/com/github/sonarperl/it/IntegrationTests.java
@@ -39,7 +39,7 @@ public class IntegrationTests {
     static {
         try {
             for (OrchestratorRule orchestratorRule : new OrchestratorRule[]{
-                orchestratorBuilderFor("10.6.0.92116").build(),
+                orchestratorBuilderFor("LATEST_RELEASE[9.9]").build(),
                 orchestratorBuilderFor("LATEST_RELEASE[10.6]").build(),
             }
             ) {

--- a/sonar-perl-plugin/build.gradle
+++ b/sonar-perl-plugin/build.gradle
@@ -10,15 +10,17 @@ repositories {
 }
 
 ext {
-    sonarApiVersion = '10.7.0.2191'
-    sonarqubeVersion = '10.6.0.92116'
+    sonarApiVersion = '9.14.0.375'
+    sonarqubeVersion = '10.7.0.96327'
 }
 
 dependencies {
     compileOnly "org.sonarsource.api.plugin:sonar-plugin-api:${sonarApiVersion}"
     testImplementation "org.sonarsource.api.plugin:sonar-plugin-api:${sonarApiVersion}"
     testImplementation "org.sonarsource.sonarqube:sonar-plugin-api-impl:${sonarqubeVersion}"
-    testImplementation "org.sonarsource.api.plugin:sonar-plugin-api-test-fixtures:${sonarApiVersion}"    
+    // there doesn't seem to be test-fixtures for 9.14.0.375 for some reason, ie.
+    // 9.9 compatibility needs to be tested via integration-testing.
+    testImplementation "org.sonarsource.api.plugin:sonar-plugin-api-test-fixtures:9.17.0.587"
     implementation 'org.apache.commons:commons-compress:1.24.0'
     implementation 'com.esotericsoftware.yamlbeans:yamlbeans:1.15'
     implementation 'com.fasterxml.staxmate:staxmate:2.4.0'


### PR DESCRIPTION
https://github.com/sonar-perl/sonar-perl/pull/151 bumped the API too high so that we lost 9.9 LTS compatibility as well as the early 10.x releases. This resets the API dependency to 9.9.
